### PR TITLE
Override min-height to retain image ratio

### DIFF
--- a/2022-June.html
+++ b/2022-June.html
@@ -110,7 +110,7 @@
                 <section>
                     <h1>Elephants!</h1>
 
-                    <img class="hoster big" src="img/logo-transparent-background.png" alt="Sponsor: AmsterdamPHP">
+                    <img class="hoster big" src="img/logo-transparent-background.png" alt="Sponsor: AmsterdamPHP" style="min-height: auto;">
                 </section>
                 <section>
                     <h1>Jetbrains license!</h1>


### PR DESCRIPTION
With this change, the image ratio gets restored to the original ratio, by overriding a fixed minimum height in the `.big` CSS class, which defines it to be at 250px